### PR TITLE
Request and store session token in ignored place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dart-tool
 .dart_tool/package_config.json
+.dart_tool/aoc
 .packages

--- a/README.md
+++ b/README.md
@@ -8,26 +8,31 @@ This is a Starter project for [AdventOfCode](https://adventofcode.com/2023), wri
 
 Feel free to fork this repository to use it as a starting point for your own solutions.
 
-### Setup
-
-Please visit the [AdventOfCode](https://adventofcode.com) site and log in. 
-
-After that, get your session token from the cookie:
-- Open DevTools (F12)
-- "Application" -> Cookies -> https://adventofcode.com
-- Copy the value of the `session` cookie
-
-Add the value to the `session` variable in the `day_generator.dart` file . This will allow the script to populate your input file.
-
-
 ### Boilerplate Generation
 
-In the root of your directory, run 
+In the root of your directory, run
+
 ```dart
 dart run day_generator.dart <day>
 ```
 
+This will request your session token if it has not been stored previously. More info can be found in the [Session token](<#Session token>) section.
+
 This will create an input and test file and a solution file with all the needed boilerplate to have a quick start. It also adds the solution to the corresponding index file, so the solution get imported into `main` automatically.
+
+### Session token
+
+When running the `day_generator.dart` script for the first time, you will be asked to provide your session token. This is needed to automatically download your input files. If you need to do this manually for any reason, you can find the instructions below.
+
+Please visit the [AdventOfCode](https://adventofcode.com) site and log in.
+
+After that, get your session token from the cookie:
+
+- Open DevTools (F12)
+- "Application" -> Cookies -> https://adventofcode.com
+- Copy the value of the `session` cookie
+
+By default, the session token is stored in `.dart_tool/aoc/.session_token`. You can either store it there manually, or run the `day_generator.dart` script and paste it when prompted.
 
 ### Main
 
@@ -37,10 +42,12 @@ Running main automatically prints either all your solutions, or just the last on
 
 It also measures the time it takes to run each solution, and prints it to the console.
 
-You can run the main file by running 
+You can run the main file by running
+
 ```dart
 dart run main.dart
 ```
+
 in the root of your directory.
 
 By default the main file will only show the last solution. If you want to see all of them, you can use the `-a` or `--all` flag.
@@ -48,7 +55,7 @@ You can list all the command line arguments by using the `-h` or `--help` flag.
 
 ### Tests
 
-A test file is automatically generated for each day. It contains tests for both parts of the example and the real input. 
+A test file is automatically generated for each day. It contains tests for both parts of the example and the real input.
 
 All you have to do is **fill out the variables given at the top of the test file.**
 
@@ -61,7 +68,6 @@ Below you can find a short documentation of the classes and methods provided by 
 ### Naming conventions
 
 When using the Boilerplate generator, everything is done for you automatically. However, if you create a solution or input file by yourself: make sure it has a 2-digit number. Concretely, pad days 1-9 as `Day01.dart` for solutions and `aoc01.txt` for input.
-
 
 ### Generic Day
 

--- a/day_generator.dart
+++ b/day_generator.dart
@@ -80,6 +80,14 @@ void main(List<String?> args) async {
     );
     request.cookies.add(Cookie('session', session));
     final response = await request.close();
+    if (response.statusCode != 200) {
+      print('''
+Received status code ${response.statusCode} from server.
+
+You might need to refresh your session token.
+You can do so by deleting the file at $sessionTokenPath and restarting the generator.''');
+      return;
+    }
     final dataPath = 'input/aoc$dayNumber.txt';
     // unawaited(File(dataPath).create());
     await response.pipe(File(dataPath).openWrite());

--- a/day_generator.dart
+++ b/day_generator.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'tool/session_token.dart';
+
 /// Small Program to be used to generate files and boilerplate for a given day.\
 /// Call with `dart run day_generator.dart <day>`
 void main(List<String?> args) async {
   const year = '2023';
-  const session = '<your session cookie here>';
+  final session = getSessionToken();
 
   if (args.length > 1) {
     print('Please call with: <dayNumber>');

--- a/tool/session_token.dart
+++ b/tool/session_token.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:io';
+
+const aocPath = '.dart_tool/aoc';
+const sessionTokenPath = '$aocPath/.session_token';
+
+String getSessionToken() {
+  final sessionToken = _readSessionToken();
+  if (sessionToken != null) {
+    return sessionToken;
+  }
+
+  final token = _promptSessionToken();
+  _writeSessionToken(token);
+  return token;
+}
+
+String? _readSessionToken() {
+  try {
+    return File(sessionTokenPath).readAsStringSync();
+  } catch (e) {
+    print('Error reading session token: $e');
+  }
+  return null;
+}
+
+void _writeSessionToken(String token) {
+  try {
+    if (!Directory(aocPath).existsSync()) {
+      Directory(aocPath).createSync(recursive: true);
+    }
+    File(sessionTokenPath).writeAsStringSync(token);
+  } catch (e) {
+    print('Error writing session token: $e');
+  }
+}
+
+String _promptSessionToken() {
+  stdout.write(_kSessionTokenPromptMessage);
+  final token = stdin.readLineSync();
+  stdout.writeln();
+  if (token == null || token.isEmpty) {
+    print('Session token cannot be empty!');
+    return _promptSessionToken();
+  }
+  return token;
+}
+
+const String _kSessionTokenPromptMessage = '''
+  ╔════════════════════════════════════════════════════════════════════════════╗
+  ║                          Session token required!                           ║
+  ║                                                                            ║
+  ║  Please visit https://adventofcode.com and log in.                         ║
+  ║                                                                            ║
+  ║  Once logged in, get your session token from the cookie:                   ║
+  ║  1. Open DevTools (F12)                                                    ║
+  ║  2. Go to Application > Cookies > https://adventofcode.com                 ║
+  ║  3. Copy the value of the `session` cookie                                 ║
+  ║                                                                            ║
+  ╚════════════════════════════════════════════════════════════════════════════╝
+
+  Please enter your session token: 
+  ''';

--- a/tool/session_token.dart
+++ b/tool/session_token.dart
@@ -16,7 +16,10 @@ String getSessionToken() {
 
 String? _readSessionToken() {
   try {
-    return File(sessionTokenPath).readAsStringSync();
+    final token = File(sessionTokenPath).readAsStringSync();
+    if (token.isNotEmpty) {
+      return token;
+    }
   } catch (e) {
     print('Error reading session token: $e');
   }

--- a/tool/session_token.dart
+++ b/tool/session_token.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_slow_async_io
-
 import 'dart:io';
 
 const aocPath = '.dart_tool/aoc';

--- a/tool/session_token.dart
+++ b/tool/session_token.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:quiver/strings.dart';
+
 const aocPath = '.dart_tool/aoc';
 const sessionTokenPath = '$aocPath/.session_token';
 
@@ -30,7 +32,7 @@ void _writeSessionToken(String token) {
   try {
     File('$aocPath/$sessionTokenPath')
         .create(recursive: true)
-        .then((file) => file.writeAsStringSync(token)),
+        .then((file) => file.writeAsStringSync(token));
   } catch (e) {
     print('Error writing session token: $e');
   }
@@ -40,11 +42,11 @@ String _promptSessionToken() {
   stdout.write(_kSessionTokenPromptMessage);
   final token = stdin.readLineSync();
   stdout.writeln();
-  if (token == null || token.isEmpty) {
+  if (isBlank(token)) {
     print('Session token cannot be empty!');
     return _promptSessionToken();
   }
-  return token;
+  return token!;
 }
 
 const String _kSessionTokenPromptMessage = '''

--- a/tool/session_token.dart
+++ b/tool/session_token.dart
@@ -28,10 +28,9 @@ String? _readSessionToken() {
 
 void _writeSessionToken(String token) {
   try {
-    if (!Directory(aocPath).existsSync()) {
-      Directory(aocPath).createSync(recursive: true);
-    }
-    File(sessionTokenPath).writeAsStringSync(token);
+    File('$aocPath/$sessionTokenPath')
+        .create(recursive: true)
+        .then((file) => file.writeAsStringSync(token)),
   } catch (e) {
     print('Error writing session token: $e');
   }


### PR DESCRIPTION
Fixes: #8 

This checks for a cached token when running the `day_generator.dart` and request and stores it for further use.
It shows the instructions directly in the terminal, allowing the user to click on the link immediately.

According to the [docs](https://dart.dev/tools/pub/package-layout), `.dart_tool/<package_name>` is a recommended place for caching data.
`.dart_tool` is mostly gitignored by default as well, but I've explicitly added `.dart_tool/aoc` to the .gitignore.

I've also put the logic in `tool/` which is mostly private files for tools. It got me thinking if we should also put the `day_generator.dart` in `bin/` and other exposed classes (currently in `utils`) under `lib`. But this is out of scope for this issue.