### PR TITLE
Fix minor issues with test template

### DIFF
--- a/day_generator.dart
+++ b/day_generator.dart
@@ -139,7 +139,7 @@ const _exampleInput1 = \'''
 /// It will be evaluated against the `_exampleSolutionPart2` below.
 ///
 /// In case the second part uses the same example, uncomment below line instead:
-// const _exampleInput2 = _exampleInput;
+// const _exampleInput2 = _exampleInput1;
 const _exampleInput2 = \'''
 \''';
 
@@ -191,7 +191,7 @@ void main() {
         skip: _puzzleSolutionPart2 == null
             ? 'Skipped because _puzzleSolutionPart2 is null'
             : false,
-        () => expect(day.solvePart1(), _puzzleSolutionPart2),
+        () => expect(day.solvePart2(), _puzzleSolutionPart2),
       );
     },
   );


### PR DESCRIPTION
I noticed 2 minor issues this morning:

- If you want to reuse the first example by uncommenting, the variable name was wrong.
- `solvePart1` was called in test for part 2