### PR TITLE
Improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-.dart-tool
+.dart_tool
 .dart_tool/package_config.json
 .packages
+build/


### PR DESCRIPTION
Typo in `.dart-tool`, instead of `.dart_tool`

Also, I think `build` is now added from running the tests. So added that one as well to the ignored files
![image](https://github.com/S-ecki/AdventOfCode-Starter-Dart/assets/2174500/41692b23-52cc-41da-87ec-72ad94cb4fbd)
