### PR TITLE
feat: make solutions optionally async

### DIFF
--- a/day_generator.dart
+++ b/day_generator.dart
@@ -111,13 +111,13 @@ class Day$dayNumber extends GenericDay {
   }
 
   @override
-  int solvePart1() {
+  Future<int> solvePart1() async {
 
     return 0;
   }
 
   @override
-  int solvePart2() {
+  Future<int> solvePart2() async {
 
     return 0;
   }
@@ -179,11 +179,11 @@ void main() {
     () {
       test('Part 1', () {
         final day = Day$day()..inputForTesting = _exampleInput1;
-        expect(day.solvePart1(), _exampleSolutionPart1);
+        () async => expect(await day.solvePart1(), _exampleSolutionPart1);
       });
       test('Part 2', () {
         final day = Day$day()..inputForTesting = _exampleInput2;
-        expect(day.solvePart2(), _exampleSolutionPart2);
+        () async => expect(await day.solvePart2(), _exampleSolutionPart2);
       });
     },
   );
@@ -196,14 +196,14 @@ void main() {
         skip: _puzzleSolutionPart1 == null
             ? 'Skipped because _puzzleSolutionPart1 is null'
             : false,
-        () => expect(day.solvePart1(), _puzzleSolutionPart1),
+        () async => expect(await day.solvePart1(), _puzzleSolutionPart1),
       );
       test(
         'Part 2',
         skip: _puzzleSolutionPart2 == null
             ? 'Skipped because _puzzleSolutionPart2 is null'
             : false,
-        () => expect(day.solvePart2(), _puzzleSolutionPart2),
+        () async => expect(await day.solvePart2(), _puzzleSolutionPart2),
       );
     },
   );

--- a/main.dart
+++ b/main.dart
@@ -8,7 +8,7 @@ final days = <GenericDay>[
   Day01(),
 ];
 
-void main(List<String?> args) {
+Future<void> main(List<String?> args) async {
   var onlyShowLast = true;
 
   if (args.length == 1 && args[0].isHelperArgument()) {
@@ -20,7 +20,7 @@ void main(List<String?> args) {
     onlyShowLast = false;
   }
 
-  onlyShowLast
+  return onlyShowLast
       ? days.last.printSolutions()
       : days.forEach((day) => day.printSolutions());
 }

--- a/tool/generic_day.dart
+++ b/tool/generic_day.dart
@@ -44,8 +44,7 @@ abstract class GenericDay {
 
   Future<SolutionWithDuration> _solveAndTrackTime(SolveFunction solve) async {
     final tracker = AsyncTimeTracker();
-    late final int solution;
-    solution = await tracker.track(solve);
+    final int solution = await tracker.track(solve);
     return (solution, tracker.duration);
   }
 

--- a/tool/generic_day.dart
+++ b/tool/generic_day.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:timing/timing.dart';
 
 import '../utils/input_util.dart';
 
-typedef SolveFunction = int Function();
+typedef SolveFunction = FutureOr<int> Function();
 typedef SolutionWithDuration = (int, Duration);
 
 /// Provides the [InputUtil] for given day and a [printSolutions] method to show
@@ -21,12 +23,17 @@ abstract class GenericDay {
       input = InputUtil.fromMultiLineString(example);
 
   dynamic parseInput();
-  int solvePart1();
-  int solvePart2();
+  FutureOr<int> solvePart1();
+  FutureOr<int> solvePart2();
 
-  void printSolutions() {
-    final result1 = _solveAndTrackTime(solvePart1);
-    final result2 = _solveAndTrackTime(solvePart2);
+  FutureOr<void> printSolutions() async {
+    final results = await Future.wait([
+      _solveAndTrackTime(solvePart1),
+      _solveAndTrackTime(solvePart2),
+    ]);
+
+    final result1 = results[0];
+    final result2 = results[1];
 
     print('-------------------------');
     print('         Day $day        ');
@@ -35,10 +42,10 @@ abstract class GenericDay {
     print('\n');
   }
 
-  SolutionWithDuration _solveAndTrackTime(SolveFunction solve) {
-    final tracker = SyncTimeTracker();
+  Future<SolutionWithDuration> _solveAndTrackTime(SolveFunction solve) async {
+    final tracker = AsyncTimeTracker();
     late final int solution;
-    tracker.track(() => solution = solve());
+    solution = await tracker.track(solve);
     return (solution, tracker.duration);
   }
 


### PR DESCRIPTION
Making solve functions `FutureOr` and adjusting the according tracking and main function.

I know `FutureOr` is not really liked by Slava but I like that for this case it allows for a smooth migration path for participants who want to migrate this season without having to touch all solutions.


Closes #28 